### PR TITLE
Añadir default en getLanguage

### DIFF
--- a/src/test/java/utilities/LocalEnviroment.java
+++ b/src/test/java/utilities/LocalEnviroment.java
@@ -88,9 +88,15 @@ public class LocalEnviroment {
 
   public static String getLanguage() {
     String language = System.getenv("Language");
+
+    if (Objects.isNull(language) || language.isEmpty()) {
+      language = "es-ES";
+    }
+
     if (!language.matches(LANGUAGE_REGEX)) {
       throw new IllegalArgumentException("Invalid language format. It should be xx-XX");
     }
+
     return language;
   }
 


### PR DESCRIPTION
## Descripción 
Esta pull request introduce una nueva comprobación en el método getLanguage de la clase LocalEnviroment.
Cuando la variable local Language es nula o vacía se pone por defecto en español.

## Tests añadidos

<img width="959" alt="image" src="https://github.com/raunelgarcia/FrontEnd-framework/assets/166013901/09a55bd5-6e65-4974-9549-673f7bbf4140">

Test hecho en caso de que la variable language sea nula
<img width="960" alt="image" src="https://github.com/raunelgarcia/FrontEnd-framework/assets/166013901/78f4bfc6-2b0b-4e8d-970a-2ef43298f291">

Test hecho en caso de que la variable language esté vacía
Language  =  ""
<img width="960" alt="image" src="https://github.com/raunelgarcia/FrontEnd-framework/assets/166013901/267c6dac-a170-4760-b59f-1b2038d0053e">

Test hecho en caso de que la variable language sea correcta
Language = "fr-FR"
<img width="960" alt="image" src="https://github.com/raunelgarcia/FrontEnd-framework/assets/166013901/c9a66ae6-3e09-419c-beee-7a7605144563">

