### PR TITLE
Language capability

### DIFF
--- a/src/test/java/utilities/DriverConfiguration.java
+++ b/src/test/java/utilities/DriverConfiguration.java
@@ -79,6 +79,7 @@ public class DriverConfiguration {
       environment = loadCapabilitiesMobile(Constants.ANDROID_CONFIG);
       capabilities = environment.get("capabilitiesAndroid");
       filledCapabilities.setCapability("appPackage", LocalEnviroment.getAppIdentifier());
+      filledCapabilities.setCapability("locale", LocalEnviroment.getLanguage());
       String apk = LocalEnviroment.getApk();
       if (Objects.nonNull(apk) && !apk.isEmpty()) {
         filledCapabilities.setCapability(

--- a/src/test/java/utilities/DriverConfiguration.java
+++ b/src/test/java/utilities/DriverConfiguration.java
@@ -79,7 +79,8 @@ public class DriverConfiguration {
       environment = loadCapabilitiesMobile(Constants.ANDROID_CONFIG);
       capabilities = environment.get("capabilitiesAndroid");
       filledCapabilities.setCapability("appPackage", LocalEnviroment.getAppIdentifier());
-      filledCapabilities.setCapability("locale", LocalEnviroment.getLanguage());
+      filledCapabilities.setCapability("language", LocalEnviroment.getLanguageCode());
+      filledCapabilities.setCapability("locale", LocalEnviroment.getCountryCode());
       String apk = LocalEnviroment.getApk();
       if (Objects.nonNull(apk) && !apk.isEmpty()) {
         filledCapabilities.setCapability(


### PR DESCRIPTION
## What
This Pull Request introduces two new capabilities in the configuration of our Android driver. This two new capabilities change the language of the test application and the environment where the tests are being executed. 

## How 
- Adds "locale" capability and gets the value of Country Code from the LocalEnvironment class.
- Adds "language" capability and gets the value of Language Code from the LocalEnvironment class. 

## Test Added 

![image](https://github.com/raunelgarcia/FrontEnd-framework/assets/161716723/ff63b321-00bc-45ba-b070-7258a455574b)

- Test case when the language is spanish 
Language = es-ES
<img width="960" alt="image" src="https://github.com/raunelgarcia/FrontEnd-framework/assets/161716723/2aa7f74c-2778-4114-9fac-39f0a1469f3b">
<img width="960" alt="image" src="https://github.com/raunelgarcia/FrontEnd-framework/assets/161716723/0bff78be-c5ca-4cc3-999e-72cdbf6cb8e2">


- Test case when the language is french
Language = fr-FR
<img width="960" alt="image" src="https://github.com/raunelgarcia/FrontEnd-framework/assets/161716723/cb210352-d873-4382-80a4-e0229d0e98c8">
<img width="960" alt="image" src="https://github.com/raunelgarcia/FrontEnd-framework/assets/161716723/9aca4a96-9ccc-4307-adbf-d6893dffe770">

- Test case when the language is english 
Language = en-US
<img width="960" alt="image" src="https://github.com/raunelgarcia/FrontEnd-framework/assets/161716723/2e4ad8d7-d4a7-45e5-b4b1-bc2c747256f1">
<img width="960" alt="image" src="https://github.com/raunelgarcia/FrontEnd-framework/assets/161716723/6d9765e0-e896-486e-af4b-85a25724d3ee">

- Test case when the language is null 
<img width="960" alt="image" src="https://github.com/raunelgarcia/FrontEnd-framework/assets/161716723/5ab5886e-1af6-40b3-b86b-2c6182cbef90">
<img width="960" alt="image" src="https://github.com/raunelgarcia/FrontEnd-framework/assets/161716723/b50be8d1-476f-4c34-ba91-9feac1a5ed17">
