### PR TITLE
Android logs

### DIFF
--- a/src/test/java/tests/CucumberRunner.java
+++ b/src/test/java/tests/CucumberRunner.java
@@ -14,6 +14,7 @@ import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import utilities.JSExecutor;
 import utilities.LocalEnviroment;
+import utilities.NetworkLogs;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(features = FEATURES_PATH, glue = CUCUMBER_STEPS_PATH)
@@ -23,7 +24,7 @@ public class CucumberRunner {
   public static void runReports() {
     runAllureReport();
     runAccesibilityCopy();
-    JSExecutor.runCommand("adb logcat -c");
+    NetworkLogs.clearLogs();
   }
 
   private static void runAllureReport() {

--- a/src/test/java/tests/CucumberRunner.java
+++ b/src/test/java/tests/CucumberRunner.java
@@ -1,12 +1,12 @@
 package tests;
 
 import static utilities.Accessibility.moveHtmlReportToAccessibilityDirectory;
-import static utilities.LocalEnviroment.isWeb;
-import static utilities.Constants.ALLURE_COMMAND_WIN;
-import static utilities.Constants.ALLURE_COMMAND_MAC;
 import static utilities.Constants.ACCESSIBILITY_REPORT_PATH;
+import static utilities.Constants.ALLURE_COMMAND_MAC;
+import static utilities.Constants.ALLURE_COMMAND_WIN;
 import static utilities.Constants.CUCUMBER_STEPS_PATH;
 import static utilities.Constants.FEATURES_PATH;
+import static utilities.LocalEnviroment.isWeb;
 
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
@@ -23,6 +23,7 @@ public class CucumberRunner {
   public static void runReports() {
     runAllureReport();
     runAccesibilityCopy();
+    JSExecutor.runCommand("adb logcat -c");
   }
 
   private static void runAllureReport() {

--- a/src/test/java/tests/cucumber_steps/MarcaSteps.java
+++ b/src/test/java/tests/cucumber_steps/MarcaSteps.java
@@ -59,7 +59,7 @@ public class MarcaSteps {
   public void closeDriver() {
     Accessibility.checkAccessibility(driver);
     AllureReport.fillReportInfo(driver);
-    NetworkLogs.getAndroidLogs();
+    NetworkLogs.getNetworkLogs();
     waitSeconds(LOW_TIMEOUT);
     driver.quit();
   }

--- a/src/test/java/tests/cucumber_steps/MarcaSteps.java
+++ b/src/test/java/tests/cucumber_steps/MarcaSteps.java
@@ -15,6 +15,7 @@ import pages.Marca;
 import utilities.Accessibility;
 import utilities.AllureReport;
 import utilities.DriverConfiguration;
+import utilities.NetworkLogs;
 
 public class MarcaSteps {
 
@@ -58,6 +59,7 @@ public class MarcaSteps {
   public void closeDriver() {
     Accessibility.checkAccessibility(driver);
     AllureReport.fillReportInfo(driver);
+    NetworkLogs.getAndroidLogs();
     waitSeconds(LOW_TIMEOUT);
     driver.quit();
   }

--- a/src/test/java/utilities/AllureReport.java
+++ b/src/test/java/utilities/AllureReport.java
@@ -7,6 +7,10 @@ import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
 import io.qameta.allure.Allure;
 import io.qameta.allure.model.Status;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
@@ -102,6 +106,15 @@ public class AllureReport {
               "<h4 style=\"background-color: #fd5a3e; padding: 8px; color: #fff;\">"
                   + comparationMessage
                   + "</h4>");
+  }
+
+  public static void attachTextFileToAllureReport(File file) {
+    try {
+      byte[] content = Files.readAllBytes(Paths.get(file.toURI()));
+      Allure.addAttachment("NetworkLogs", "text/plain", new String(content));
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
   }
 
   public static void attachScreenshot(WebDriver driver) {

--- a/src/test/java/utilities/AllureReport.java
+++ b/src/test/java/utilities/AllureReport.java
@@ -64,9 +64,13 @@ public class AllureReport {
         description.append("<p><b>Apk:</b> ").append(apk).append("</p>");
       }
     } else {
-      if (LocalEnviroment.isWindows()) { os = "Windows"; }
-      else if (LocalEnviroment.isMac()) { os = "Mac"; }
-      else { os = "linux"; }
+      if (LocalEnviroment.isWindows()) {
+        os = "Windows";
+      } else if (LocalEnviroment.isMac()) {
+        os = "Mac";
+      } else {
+        os = "linux";
+      }
       description.append("<p><b>Browser:</b> ").append(LocalEnviroment.getBrowser()).append("</p>");
       description
           .append("<p><b>Url:</b> ")

--- a/src/test/java/utilities/Constants.java
+++ b/src/test/java/utilities/Constants.java
@@ -14,11 +14,12 @@ public class Constants {
   public static final String IOS_CONFIG = "yaml/iOSConfiguration.yaml";
   public static final String WEB_CONFIG = "yaml/webConfiguration.yaml";
   public static final String DRIVER_URL = "http://127.0.0.1:4723";
-  public static final String ALLURE_COMMAND_WIN = "npx allure generate target/allure-results --clean && npx allure open";
-  public static final String ALLURE_COMMAND_MAC = "npx allure generate target/allure-results --clean; npx allure open";
+  public static final String ALLURE_COMMAND_WIN =
+      "npx allure generate target/allure-results --clean && npx allure open";
+  public static final String ALLURE_COMMAND_MAC =
+      "npx allure generate target/allure-results --clean; npx allure open";
   public static final String ACCESSIBILITY_REPORT_PATH = "target/java-a11y/";
   public static final String CUCUMBER_STEPS_PATH = "tests/cucumber_steps";
   public static final String FEATURES_PATH = "src/test/resources/features";
   public static final String ALLOWED_RESOLUTIONS_PATH = "yaml/allowedResolutions.yaml";
-
 }

--- a/src/test/java/utilities/Generator.java
+++ b/src/test/java/utilities/Generator.java
@@ -1,13 +1,12 @@
 package utilities;
 
-import pages.BasePage;
-
 import static utilities.Constants.GMAIL_DOMAIN;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Random;
+import pages.BasePage;
 
 public class Generator {
   private static final String CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";

--- a/src/test/java/utilities/JSExecutor.java
+++ b/src/test/java/utilities/JSExecutor.java
@@ -2,16 +2,12 @@ package utilities;
 
 import io.qameta.allure.Allure;
 import io.qameta.allure.model.Status;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.WebDriver;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.sql.Driver;
 import java.util.ArrayList;
-
-import utilities.DriverConfiguration;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
 
 public class JSExecutor {
 

--- a/src/test/java/utilities/LocalEnviroment.java
+++ b/src/test/java/utilities/LocalEnviroment.java
@@ -67,9 +67,13 @@ public class LocalEnviroment {
     return System.getenv("Platform").equalsIgnoreCase("iOS");
   }
 
-  public static boolean isWindows() { return System.getProperty("os.name").toLowerCase().contains("win"); }
+  public static boolean isWindows() {
+    return System.getProperty("os.name").toLowerCase().contains("win");
+  }
 
-  public static boolean isMac() { return System.getProperty("os.name").toLowerCase().contains("mac"); }
+  public static boolean isMac() {
+    return System.getProperty("os.name").toLowerCase().contains("mac");
+  }
 
   public static String getApplicationUrl() throws IllegalArgumentException {
     Map<String, Map<String, String>> environment = DriverConfiguration.loadCapabilitiesWeb();

--- a/src/test/java/utilities/LocalEnviroment.java
+++ b/src/test/java/utilities/LocalEnviroment.java
@@ -1,11 +1,10 @@
 package utilities;
 
-import pages.BasePage;
-
 import static utilities.Constants.LANGUAGE_REGEX;
 
 import java.util.Map;
 import java.util.Objects;
+import pages.BasePage;
 
 public class LocalEnviroment {
 

--- a/src/test/java/utilities/NetworkLogs.java
+++ b/src/test/java/utilities/NetworkLogs.java
@@ -1,0 +1,43 @@
+package utilities;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class NetworkLogs {
+  public static void getAndroidLogs() {
+    try {
+      ProcessBuilder processBuilder =
+          new ProcessBuilder("cmd.exe", "/c", "adb logcat -d | findstr okhttp.OkHttpClient");
+      processBuilder.redirectErrorStream(true);
+      Process process = processBuilder.start();
+
+      BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+      StringBuilder output = new StringBuilder();
+      String line;
+      while ((line = reader.readLine()) != null) {
+        output.append(line).append("\n");
+      }
+
+      File logsFolder = new File("network-logs");
+      if (!logsFolder.exists()) {
+        logsFolder.mkdir();
+      }
+      String fileName = "logs_" + System.currentTimeMillis() + ".txt";
+      File outputFile = new File(logsFolder, fileName);
+      try (FileWriter writer = new FileWriter(outputFile)) {
+        writer.write(output.toString());
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+
+      process.waitFor();
+      reader.close();
+
+    } catch (IOException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/test/java/utilities/NetworkLogs.java
+++ b/src/test/java/utilities/NetworkLogs.java
@@ -7,6 +7,11 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 public class NetworkLogs {
+  public static void getNetworkLogs() {
+    if (LocalEnviroment.isAndroid()) getAndroidLogs();
+    // TODO create logs from other platforms
+  }
+
   public static void getAndroidLogs() {
     try {
       ProcessBuilder processBuilder =
@@ -40,5 +45,10 @@ public class NetworkLogs {
     } catch (IOException | InterruptedException e) {
       e.printStackTrace();
     }
+  }
+
+  public static void clearLogs() {
+    if (LocalEnviroment.isAndroid()) JSExecutor.runCommand("adb logcat -c");
+    // TODO clear logs from other platforms
   }
 }

--- a/src/test/java/utilities/NetworkLogs.java
+++ b/src/test/java/utilities/NetworkLogs.java
@@ -29,6 +29,7 @@ public class NetworkLogs {
       File outputFile = new File(logsFolder, fileName);
       try (FileWriter writer = new FileWriter(outputFile)) {
         writer.write(output.toString());
+        AllureReport.attachTextFileToAllureReport(outputFile);
       } catch (IOException e) {
         e.printStackTrace();
       }


### PR DESCRIPTION
Añadida la funcion para adjuntar los network logs al reporte de Allure. Se integra perfectamente en Allure y está pensado para ir rellenando los logs en funcion de la plataforma en la que se ejecuten los tests en un futuro. De momento solo queda implementada la parte de android.

<img width="960" alt="test2" src="https://github.com/raunelgarcia/front-end-framework/assets/160595613/a2c228c8-8c91-45fd-8f77-0f28039959ba">
<img width="960" alt="test1" src="https://github.com/raunelgarcia/front-end-framework/assets/160595613/dcece105-834b-47ac-8111-1071587b656f">
