### PR TITLE
Allure results and reports previous history eliminated along with Network logs previous history .

### DIFF
--- a/src/test/java/tests/MarcaTest.java
+++ b/src/test/java/tests/MarcaTest.java
@@ -9,10 +9,7 @@ import static utilities.Constants.ALLURE_COMMAND_MAC;
 import static utilities.Constants.ALLURE_COMMAND_WIN;
 import static utilities.LocalEnviroment.isWeb;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import pages.Marca;
 import utilities.*;
@@ -23,6 +20,13 @@ import utilities.LocalEnviroment;
 public class MarcaTest {
 
   private static Marca controller;
+
+  @BeforeAll
+  public static void clean_allure_report() {
+    JSExecutor.runCommand(ALLURE_CLEAN_COMMAND);
+    JSExecutor.runCommand(NETWORK_LOG_CLEAN_COMMAND);
+  }
+
 
   @BeforeEach
   public void iAmOnTheMarcaWebsite() {

--- a/src/test/java/utilities/Constants.java
+++ b/src/test/java/utilities/Constants.java
@@ -20,4 +20,7 @@ public class Constants {
       "npx allure generate target/allure-results --clean; npx allure open";
   public static final String ACCESSIBILITY_REPORT_PATH = "target/java-a11y/";
   public static final String ALLOWED_RESOLUTIONS_PATH = "yaml/allowedResolutions.yaml";
+  public static final String ALLURE_CLEAN_COMMAND =
+      "rd /s /q .\\target\\allure-results\\ && rd /s /q .\\allure-report\\";
+  public static final String NETWORK_LOG_CLEAN_COMMAND = "rd /s /q .\\network-logs\\";
 }


### PR DESCRIPTION
## What
This pull request introduces new implementation that deletes the previous Allure-results and Allure-reports history. When running mobile it also deletes the network-logs history.

## How
- Two new constants added. One that stores the command to delete the Allure-results directory and the Allure-reports directory. The other constant contains the command to delete the network-logs directory.
- In the MarcaTest, implemented a @BeforeAll function that calls the JSExecutor to run the previous two commands to eliminate 
Allure-results directory, Allure-reports directory  and the network-logs directory.

## Test added
Directory tree before running tests with previous history:
![image](https://github.com/raunelgarcia/front-end-framework/assets/167751395/22e12f34-9621-4f85-9848-2352e37d6400)

Directory tree after running a web test (the network-logs folder doesn't exist anymore because a web test was executed):
![image](https://github.com/raunelgarcia/front-end-framework/assets/167751395/8e961f4b-384a-4176-b0db-6316e6b2b655)

Build:
![image](https://github.com/raunelgarcia/front-end-framework/assets/167751395/e7038916-a63c-462b-ac53-38990e1b857f)


