### PR TITLE
Open SauceLabs with the suggested Version

### DIFF
--- a/src/main/java/saucelabs/api/SauceLabsAPI.java
+++ b/src/main/java/saucelabs/api/SauceLabsAPI.java
@@ -1,10 +1,6 @@
 package saucelabs.api;
 
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.HeaderParam;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -14,4 +10,11 @@ public interface SauceLabsAPI {
   @Produces(MediaType.APPLICATION_JSON)
   Response getV1StorageFiles(
           @HeaderParam("Authorization") String authorization, @QueryParam("q") String appId, @QueryParam("kind") String kind, @QueryParam("per_page") Integer perPage);
+
+  @GET
+  @Path("/rest/v1/info/platforms/{automation_api}")
+  @Produces(MediaType.APPLICATION_JSON)
+  Response getWebDriverPlatforms(
+      @HeaderParam("Authorization") String authorization,
+      @PathParam("automation_api") String automation_api);
 }

--- a/src/main/java/saucelabs/dto/AppBrowserVersion.java
+++ b/src/main/java/saucelabs/dto/AppBrowserVersion.java
@@ -1,0 +1,12 @@
+package saucelabs.dto;
+
+import lombok.Data;
+
+@Data
+public class AppBrowserVersion {
+  private String short_version;
+  private String long_name;
+  private String api_name;
+  private String long_version;
+  private String os;
+}

--- a/src/main/java/saucelabs/service/SauceLabsService.java
+++ b/src/main/java/saucelabs/service/SauceLabsService.java
@@ -1,11 +1,14 @@
 package saucelabs.service;
 
 import jakarta.ws.rs.core.GenericType;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import saucelabs.api.Response;
 import saucelabs.client.SauceLabsClient;
+import saucelabs.dto.AppBrowserVersion;
 import saucelabs.dto.AppStorageResponse;
 
 @Service
@@ -35,5 +38,12 @@ public class SauceLabsService {
         Optional.empty(), // No direct class provided, we'll use GenericType
         new GenericType<AppStorageResponse>() {} // Use GenericType for complex types
         );
+  }
+
+  public Response<List<AppBrowserVersion>> getBrowserVersion(String authorization) {
+    return sauceLabsClient.call(
+        () -> sauceLabsClient.getAPI().getWebDriverPlatforms(authorization, "webdriver"),
+        Optional.empty(),
+        new GenericType<List<AppBrowserVersion>>() {});
   }
 }

--- a/src/main/java/utilities/LocalEnviroment.java
+++ b/src/main/java/utilities/LocalEnviroment.java
@@ -220,4 +220,12 @@ public class LocalEnviroment {
   public static String getCountryCode() {
     return getLanguage().split("-")[1];
   }
+
+  public static String getBrowserVersion() {
+    String version = System.getenv("BrowserVersion");
+    if (FrontEndOperation.isNullOrEmpty(version)) {
+      return "latest";
+    }
+    return version.toLowerCase();
+  }
 }

--- a/src/main/java/utilities/SaucelabsDriverConfiguration.java
+++ b/src/main/java/utilities/SaucelabsDriverConfiguration.java
@@ -1,17 +1,21 @@
 package utilities;
 
 import static org.apache.http.HttpStatus.SC_OK;
+import static utilities.Constants.AUTHORIZATION;
 import static utilities.LocalEnviroment.*;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.openqa.selenium.MutableCapabilities;
 import saucelabs.api.ApiUtils;
 import saucelabs.api.Response;
 import saucelabs.client.SauceLabsClient;
+import saucelabs.dto.AppBrowserVersion;
 import saucelabs.dto.AppStorageItemMetadataResponse;
 import saucelabs.dto.AppStorageResponse;
 import saucelabs.service.SauceLabsService;
+import saucelabs.dto.AppBrowserVersion;
 
 public class SaucelabsDriverConfiguration {
 
@@ -118,9 +122,92 @@ public class SaucelabsDriverConfiguration {
     } else {
       capabilities.setCapability("platformName", "macOS 13");
     }
-    capabilities.setCapability("browserVersion", "latest");
+
+    capabilities.setCapability("browserVersion", setVersionBrowser());
     MutableCapabilities sauceOptions = getSauceOptions();
     sauceOptions.setCapability("extendedDebugging", true);
     capabilities.setCapability("sauce:options", sauceOptions);
+  }
+
+  public static String setVersionBrowser() {
+    String browser;
+    checkValidVersion();
+    SauceLabsService sauceLabsService = new SauceLabsService(new SauceLabsClient());
+    if (getBrowser().equalsIgnoreCase("edge")) {
+      browser = "MicrosoftEdge";
+    } else {
+      browser = LocalEnviroment.getBrowser();
+    }
+    Response<List<AppBrowserVersion>> response = sauceLabsService.getBrowserVersion(AUTHORIZATION);
+    AppBrowserVersion[] browserVersionArray =
+        response.getPayload().toArray(new AppBrowserVersion[0]);
+    for (AppBrowserVersion Versions : browserVersionArray) {
+      if (isMatchingVersion(Versions, browser, LocalEnviroment.getBrowserVersion())) {
+        Logger.infoMessage(
+            "The suggested version is Available: \n"
+                + "Operating System: "
+                + Versions.getOs()
+                + "\nSuggested Version: "
+                + Versions.getShort_version()
+                + "\nBrowser Name: "
+                + Versions.getApi_name());
+        return LocalEnviroment.getBrowserVersion();
+      } else if (LocalEnviroment.getBrowserVersion().equalsIgnoreCase("latest")
+          && Objects.equals(Versions.getOs(), "Windows 11")
+          && Objects.equals(Versions.getApi_name(), browser)) {
+        Logger.infoMessage(
+            "The suggested version is Available: \n"
+                + "Operating System: "
+                + Versions.getOs()
+                + "\nSuggested Version: "
+                + "latest"
+                + "\nBrowser Name: "
+                + Versions.getApi_name());
+        return LocalEnviroment.getBrowserVersion();
+      }
+    }
+    Logger.errorMessage(
+        "The suggested Version is not available, check if the Enviroments Variables are correct.");
+    throw new RuntimeException("The version you specified was not found or is invalid.");
+  }
+
+  public static boolean isMatchingVersion(
+      AppBrowserVersion versionObj, String browser, String version) {
+    return Objects.equals(versionObj.getApi_name(), browser)
+        && Objects.equals(versionObj.getShort_version(), version)
+        && Objects.equals(versionObj.getOs(), "Windows 11");
+  }
+
+  public static void checkValidVersion() {
+    switch (LocalEnviroment.getBrowser()) {
+      case "edge":
+        {
+          if (!LocalEnviroment.getBrowserVersion().equalsIgnoreCase("latest")
+              && Integer.parseInt(LocalEnviroment.getBrowserVersion()) < 95) {
+            throw new RuntimeException(
+                "For Edge browsers, ensure that the version is greater than 95.");
+          }
+        }
+      case "firefox":
+        {
+          {
+            if (!LocalEnviroment.getBrowserVersion().equalsIgnoreCase("latest")
+                && Integer.parseInt(LocalEnviroment.getBrowserVersion()) < 95) {
+              throw new RuntimeException(
+                  "For Firefox browsers, ensure that the version is greater than 95.");
+            }
+          }
+        }
+      case "chrome":
+        {
+          {
+            if (!LocalEnviroment.getBrowserVersion().equalsIgnoreCase("latest")
+                && Integer.parseInt(LocalEnviroment.getBrowserVersion()) < 90) {
+              throw new RuntimeException(
+                  "For Chrome browsers, ensure that the version is greater than 90.");
+            }
+          }
+        }
+    }
   }
 }


### PR DESCRIPTION
**Description**
The program retrieves the local environment variables from getBrowserVersion, compares that data with the results from the API, and checks if the version, the operating system (specifically Windows 11), and the browser match. If all these conditions are met, the setVersionBrowser function returns the corresponding version, and Sauce Labs is executed with the specifications provided through the environment variables. If these conditions are not met, the function will return an error.

**How**
The first step was to create a new DTO named AppBrowserVersion containing the variables that would later be required. In SauceLabsService, a function was added that returns a list composed of a collection of DTOs. To generate this response, a method declaration for the API REST was added in SauceLabsAPI.
Once the response is obtained, it is passed to a function called setVersionBrowser, which is responsible for performing the necessary checks and modifications to determine if the environment variables match the variables in a specific DTO.
If a match is found, the corresponding version is returned; otherwise, an error is thrown, indicating the specific issue.
Once everything is functioning correctly, the version in question is passed to the setSauceWebCapabilities function using capabilities.setCapability("browserVersion", setVersionBrowser());, and the rest of the process continues normally.

**Evidence**

<img width="862" alt="CorrectoEdge" src="https://github.com/user-attachments/assets/fd23f1f0-2ff8-4891-9271-6c3ccd0f282c">
This image represents a successful execution of Edge, where it is evident that the version was found and SauceLabsTest was invoked correctly. Below, I demonstrate that it has been successfully launched in SauceLabs, using version 100, which was passed through an environment variable:

<img width="745" alt="SauceLabsCorrectEdge" src="https://github.com/user-attachments/assets/9005fba8-ca75-4143-9167-7c02e3894da9">

Now, I will do the same with a version lower than the recommended one. Although this version is found in the database, it will return an error because it is not supported by the W3C, resulting in an error if we attempt to use lower versions.

<img width="819" alt="LowerVersionEdge" src="https://github.com/user-attachments/assets/7df2e6a7-8941-4047-832b-67f75a18515e">

The rest of the tests work in the same way, and they will all be executed this Wednesday.

