### PR TITLE
Changes to Response Name and modify the checkValidVersion function

### DIFF
--- a/src/main/java/saucelabs/api/SauceLabsAPI.java
+++ b/src/main/java/saucelabs/api/SauceLabsAPI.java
@@ -14,7 +14,7 @@ public interface SauceLabsAPI {
   @GET
   @Path("/rest/v1/info/platforms/{automation_api}")
   @Produces(MediaType.APPLICATION_JSON)
-  Response getWebDriverPlatforms(
+  Response getV1InfoPlatformsAutomationApi(
       @HeaderParam("Authorization") String authorization,
       @PathParam("automation_api") String automation_api);
 }

--- a/src/main/java/saucelabs/service/SauceLabsService.java
+++ b/src/main/java/saucelabs/service/SauceLabsService.java
@@ -42,7 +42,7 @@ public class SauceLabsService {
 
   public Response<List<AppBrowserVersion>> getBrowserVersion(String authorization) {
     return sauceLabsClient.call(
-        () -> sauceLabsClient.getAPI().getWebDriverPlatforms(authorization, "webdriver"),
+        () -> sauceLabsClient.getAPI().getV1InfoPlatformsAutomationApi(authorization, "webdriver"),
         Optional.empty(),
         new GenericType<List<AppBrowserVersion>>() {});
   }

--- a/src/main/java/utilities/SaucelabsDriverConfiguration.java
+++ b/src/main/java/utilities/SaucelabsDriverConfiguration.java
@@ -180,22 +180,12 @@ public class SaucelabsDriverConfiguration {
 
   public static void checkValidVersion() {
     switch (LocalEnviroment.getBrowser()) {
-      case "edge":
+      case "edge", "firefox":
         {
           if (!LocalEnviroment.getBrowserVersion().equalsIgnoreCase("latest")
               && Integer.parseInt(LocalEnviroment.getBrowserVersion()) < 95) {
             throw new RuntimeException(
-                "For Edge browsers, ensure that the version is greater than 95.");
-          }
-        }
-      case "firefox":
-        {
-          {
-            if (!LocalEnviroment.getBrowserVersion().equalsIgnoreCase("latest")
-                && Integer.parseInt(LocalEnviroment.getBrowserVersion()) < 95) {
-              throw new RuntimeException(
-                  "For Firefox browsers, ensure that the version is greater than 95.");
-            }
+                "For " + getBrowser() + ", ensure that the version is greater than 95.");
           }
         }
       case "chrome":


### PR DESCRIPTION
**Description**
I have changed the name of the response returned by the API, as it can now be used in a more versatile manner. However, the previous function name was more focused on a specific case.
Also in the function located in SaucelabsDriverConfiguration.java, within checkValidVersion(), the responses for Firefox and Edge were similar, so I have unified them into a single response.